### PR TITLE
[bugfix] Removing scoped filter while discovering packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use the following dependency in your code.
     <dependency>
         <groupId>io.appform.hope</groupId>
         <artifactId>hope-lang</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </dependency>
 ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,10 @@
+# 2.0.4
+- Bugfix: Removed the filterInputsBy package line, which prevents scanning custom packages that are registered on hopebuilder
+
 # 2.0.3
 - Bugfix in `pointer.exists`
 - Version bump for vulnerable components
-- 
+ 
 # 2.0.2
 - Added equals and hashCode to value types
 

--- a/hope-core/pom.xml
+++ b/hope-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hope-core/src/main/java/io/appform/hope/core/functions/FunctionRegistry.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/FunctionRegistry.java
@@ -75,8 +75,7 @@ public class FunctionRegistry {
         Reflections reflections = new Reflections(
                 new ConfigurationBuilder()
                         .setUrls(packageUrls)
-                        .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner())
-                        .filterInputsBy(new FilterBuilder().includePackage("io.appform.hope.core.functions.impl")));
+                        .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner()));
         log.debug("Type scanning complete");
         final Set<Class<? extends HopeFunction>> classes = reflections.getSubTypesOf(HopeFunction.class);
         classes

--- a/hope-lang/pom.xml
+++ b/hope-lang/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.hope</groupId>
     <artifactId>hope</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
 
     <name>Hope</name>
     <url>https://github.com/santanusinha/hope</url>


### PR DESCRIPTION
Removed the filterInputsBy package line, which prevents scanning custom packages that are registered on hopebuilder.