### PR TITLE
Added datetime helper functions

### DIFF
--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current day of the month as a NumericValue.
+ */
+@FunctionImplementation("datetime.day_of_month")
+public class DayOfMonth extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getDayOfMonth());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current day of the month as a NumericValue.
  */
-@FunctionImplementation("datetime.day_of_month")
+@FunctionImplementation("date.day_of_month")
 public class DayOfMonth extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current day of the week as a NumericValue.
+ */
+@FunctionImplementation("datetime.day_of_week")
+public class DayOfWeek extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getDayOfWeek().getValue());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current day of the week as a NumericValue.
  */
-@FunctionImplementation("datetime.day_of_week")
+@FunctionImplementation("date.day_of_week")
 public class DayOfWeek extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current day of the year as a NumericValue.
  */
-@FunctionImplementation("datetime.day_of_year")
+@FunctionImplementation("date.day_of_year")
 public class DayOfYear extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current day of the year as a NumericValue.
+ */
+@FunctionImplementation("datetime.day_of_year")
+public class DayOfYear extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getDayOfYear());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * Returns the current hour of the day as a NumericValue.
  */
-@FunctionImplementation("datetime.hour_of_day")
+@FunctionImplementation("date.hour_of_day")
 public class HourOfDay extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * Returns the current hour of the day as a NumericValue.
+ */
+@FunctionImplementation("datetime.hour_of_day")
+public class HourOfDay extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getHour());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * Returns the current minute of the hour as a NumericValue.
  */
-@FunctionImplementation("datetime.minute_of_hour")
+@FunctionImplementation("date.minute_of_hour")
 public class MinuteOfHour extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * Returns the current minute of the hour as a NumericValue.
+ */
+@FunctionImplementation("datetime.minute_of_hour")
+public class MinuteOfHour extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getMinute());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+/**
+ * returns the current month of the year as a NumericValue.
+ */
+@FunctionImplementation("datetime.month_of_year")
+public class MonthOfYear extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getMonth().getValue());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 /**
  * returns the current month of the year as a NumericValue.
  */
-@FunctionImplementation("datetime.month_of_year")
+@FunctionImplementation("date.month_of_year")
 public class MonthOfYear extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
@@ -22,7 +22,7 @@ import io.appform.hope.core.visitors.Evaluator;
 /**
  * Returns current UNIX epoch time {@link NumericValue} in milliseconds.
  */
-@FunctionImplementation("datetime.now")
+@FunctionImplementation("date.now")
 public class Now extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+/**
+ * Returns current UNIX epoch time {@link NumericValue} in milliseconds.
+ */
+@FunctionImplementation("datetime.now")
+public class Now extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(System.currentTimeMillis());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * Returns the current second of the minute as a NumericValue.
+ */
+@FunctionImplementation("datetime.second_of_minute")
+public class SecondOfMinute extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getSecond());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * Returns the current second of the minute as a NumericValue.
  */
-@FunctionImplementation("datetime.second_of_minute")
+@FunctionImplementation("date.second_of_minute")
 public class SecondOfMinute extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 /**
  * returns the current week of the month as a NumericValue.
  */
-@FunctionImplementation("datetime.week_of_month")
+@FunctionImplementation("date.week_of_month")
 public class WeekOfMonth extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+/**
+ * returns the current week of the month as a NumericValue.
+ */
+@FunctionImplementation("datetime.week_of_month")
+public class WeekOfMonth extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().get(WeekFields.of(Locale.getDefault()).weekOfMonth()));
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+/**
+ * returns the current week of the year as a NumericValue.
+ */
+@FunctionImplementation("datetime.week_of_year")
+public class WeekOfYear extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().get(WeekFields.of(Locale.getDefault()).weekOfYear()));
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 /**
  * returns the current week of the year as a NumericValue.
  */
-@FunctionImplementation("datetime.week_of_year")
+@FunctionImplementation("date.week_of_year")
 public class WeekOfYear extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current year as a NumericValue.
+ */
+@FunctionImplementation("datetime.year")
+public class Year extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getYear());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current year as a NumericValue.
  */
-@FunctionImplementation("datetime.year")
+@FunctionImplementation("date.year")
 public class Year extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
+++ b/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
@@ -242,17 +242,17 @@ class LibraryFunctionsTest {
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len(\"/array\") == 6", true),
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len('/array') == 6", true),
 
-                Arguments.of("{}", "math.sub(datetime.now(), %d) <= 1000 && math.sub(datetime.now(), %d) >= 0".formatted(epochMilli, epochMilli), true),
-                Arguments.of("{}", "math.sub(datetime.second_of_minute(), %d) <= 1 && math.sub(datetime.second_of_minute(), %d) >= 0".formatted(dateTime.getSecond(), dateTime.getSecond()), true),
-                Arguments.of("{}", "math.sub(datetime.minute_of_hour(), %d) <= 1 && math.sub(datetime.minute_of_hour(), %d) >= 0".formatted(dateTime.getMinute(), dateTime.getMinute()), true),
-                Arguments.of("{}", "math.sub(datetime.hour_of_day(), %d) <= 1 && math.sub(datetime.hour_of_day(), %d) >= 0".formatted(dateTime.getHour(), dateTime.getHour()), true),
-                Arguments.of("{}", "math.sub(datetime.day_of_week(), %d) <= 1 && math.sub(datetime.day_of_week(), %d) >= 0".formatted(dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue()), true),
-                Arguments.of("{}", "math.sub(datetime.day_of_month(), %d) <= 1 && math.sub(datetime.day_of_month(), %d) >= 0".formatted(dateTime.getDayOfMonth(), dateTime.getDayOfMonth()), true),
-                Arguments.of("{}", "math.sub(datetime.day_of_year(), %d) <= 1 && math.sub(datetime.day_of_year(), %d) >= 0".formatted(dateTime.getDayOfYear(), dateTime.getDayOfYear()), true),
-                Arguments.of("{}", "math.sub(datetime.week_of_month(), %d) <= 1 && math.sub(datetime.week_of_month(), %d) >= 0".formatted(weekOfMonth, weekOfMonth), true),
-                Arguments.of("{}", "math.sub(datetime.week_of_year(), %d) <= 1 && math.sub(datetime.week_of_year(), %d) >= 0".formatted(weekOfYear, weekOfYear), true),
-                Arguments.of("{}", "math.sub(datetime.month_of_year(), %d) <= 1 && math.sub(datetime.month_of_year(), %d) >= 0".formatted(dateTime.getMonth().getValue(), dateTime.getMonth().getValue()), true),
-                Arguments.of("{}", "math.sub(datetime.year(), %d) <= 1 && math.sub(datetime.year(), %d) >= 0".formatted(dateTime.getYear(), dateTime.getYear()), true)
+                Arguments.of("{}", "math.sub(date.now(), %d) <= 2000 && math.sub(date.now(), %d) >= 0".formatted(epochMilli, epochMilli), true),
+                Arguments.of("{}", "math.sub(date.second_of_minute(), %d) <= 1 && math.sub(date.second_of_minute(), %d) >= 0".formatted(dateTime.getSecond(), dateTime.getSecond()), true),
+                Arguments.of("{}", "math.sub(date.minute_of_hour(), %d) <= 1 && math.sub(date.minute_of_hour(), %d) >= 0".formatted(dateTime.getMinute(), dateTime.getMinute()), true),
+                Arguments.of("{}", "math.sub(date.hour_of_day(), %d) <= 1 && math.sub(date.hour_of_day(), %d) >= 0".formatted(dateTime.getHour(), dateTime.getHour()), true),
+                Arguments.of("{}", "math.sub(date.day_of_week(), %d) <= 1 && math.sub(date.day_of_week(), %d) >= 0".formatted(dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue()), true),
+                Arguments.of("{}", "math.sub(date.day_of_month(), %d) <= 1 && math.sub(date.day_of_month(), %d) >= 0".formatted(dateTime.getDayOfMonth(), dateTime.getDayOfMonth()), true),
+                Arguments.of("{}", "math.sub(date.day_of_year(), %d) <= 1 && math.sub(date.day_of_year(), %d) >= 0".formatted(dateTime.getDayOfYear(), dateTime.getDayOfYear()), true),
+                Arguments.of("{}", "math.sub(date.week_of_month(), %d) <= 1 && math.sub(date.week_of_month(), %d) >= 0".formatted(weekOfMonth, weekOfMonth), true),
+                Arguments.of("{}", "math.sub(date.week_of_year(), %d) <= 1 && math.sub(date.week_of_year(), %d) >= 0".formatted(weekOfYear, weekOfYear), true),
+                Arguments.of("{}", "math.sub(date.month_of_year(), %d) <= 1 && math.sub(date.month_of_year(), %d) >= 0".formatted(dateTime.getMonth().getValue(), dateTime.getMonth().getValue()), true),
+                Arguments.of("{}", "math.sub(date.year(), %d) <= 1 && math.sub(date.year(), %d) >= 0".formatted(dateTime.getYear(), dateTime.getYear()), true)
 
                  );
     }


### PR DESCRIPTION
The following are now available as built-in functions
```
datetime.now()
datetime.second_of_minute()
datetime.minute_of_hour()
datetime.hour_of_day()
datetime.day_of_week()
datetime.day_of_month()
datetime.day_of_year()
datetime.week_of_month()
datetime.week_of_year()
datetime.month_of_year()
datetime.year()
```