### PR TITLE
Added date helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use the following dependency in your code.
     <dependency>
         <groupId>io.appform.hope</groupId>
         <artifactId>hope-lang</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
     </dependency>
 ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+# 2.0.5
+- A host of Date functions are now supported as built-in functions 
+  - `date.now()`, `date.secondOfMinute()`, `date.minuteOfHour()`, `date.hourOfDay()`, `date.dayOfWeek()`, `date.dayOfMonth()`, `date.dayOfYear()`, `date.weekOfMonth()`, `date.weekOfYear()`, `date.monthOfYear()`, `date.year()`
+
 # 2.0.4
 - Bugfix: Removed the filterInputsBy package line, which prevents scanning custom packages that are registered on hopebuilder
 

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,4 +1,4 @@
-io.appform.hope:hope:pom:2.0.4
+io.appform.hope:hope:pom:2.0.5
 +- org.openjdk.jmh:jmh-core:jar:1.35:test
 |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
 |  \- org.apache.commons:commons-math3:jar:3.2:test

--- a/hope-core/dependencies.txt
+++ b/hope-core/dependencies.txt
@@ -1,4 +1,4 @@
-io.appform.hope:hope-core:jar:2.0.4
+io.appform.hope:hope-core:jar:2.0.5
 +- org.reflections:reflections:jar:0.9.12:compile
 |  \- org.javassist:javassist:jar:3.26.0-GA:compile
 +- org.openjdk.jmh:jmh-core:jar:1.35:test

--- a/hope-core/dependency-reduced-pom.xml
+++ b/hope-core/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>hope</artifactId>
     <groupId>io.appform.hope</groupId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hope-core</artifactId>

--- a/hope-core/pom.xml
+++ b/hope-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current day of the month as a NumericValue.
+ */
+@FunctionImplementation("datetime.day_of_month")
+public class DayOfMonth extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getDayOfMonth());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfMonth.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current day of the month as a NumericValue.
  */
-@FunctionImplementation("datetime.day_of_month")
+@FunctionImplementation("date.day_of_month")
 public class DayOfMonth extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current day of the week as a NumericValue.
+ */
+@FunctionImplementation("datetime.day_of_week")
+public class DayOfWeek extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getDayOfWeek().getValue());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfWeek.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current day of the week as a NumericValue.
  */
-@FunctionImplementation("datetime.day_of_week")
+@FunctionImplementation("date.day_of_week")
 public class DayOfWeek extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current day of the year as a NumericValue.
  */
-@FunctionImplementation("datetime.day_of_year")
+@FunctionImplementation("date.day_of_year")
 public class DayOfYear extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/DayOfYear.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current day of the year as a NumericValue.
+ */
+@FunctionImplementation("datetime.day_of_year")
+public class DayOfYear extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getDayOfYear());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * Returns the current hour of the day as a NumericValue.
  */
-@FunctionImplementation("datetime.hour_of_day")
+@FunctionImplementation("date.hour_of_day")
 public class HourOfDay extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/HourOfDay.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * Returns the current hour of the day as a NumericValue.
+ */
+@FunctionImplementation("datetime.hour_of_day")
+public class HourOfDay extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getHour());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * Returns the current minute of the hour as a NumericValue.
  */
-@FunctionImplementation("datetime.minute_of_hour")
+@FunctionImplementation("date.minute_of_hour")
 public class MinuteOfHour extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MinuteOfHour.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * Returns the current minute of the hour as a NumericValue.
+ */
+@FunctionImplementation("datetime.minute_of_hour")
+public class MinuteOfHour extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getMinute());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+/**
+ * returns the current month of the year as a NumericValue.
+ */
+@FunctionImplementation("datetime.month_of_year")
+public class MonthOfYear extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getMonth().getValue());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/MonthOfYear.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 /**
  * returns the current month of the year as a NumericValue.
  */
-@FunctionImplementation("datetime.month_of_year")
+@FunctionImplementation("date.month_of_year")
 public class MonthOfYear extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
@@ -22,7 +22,7 @@ import io.appform.hope.core.visitors.Evaluator;
 /**
  * Returns current UNIX epoch time {@link NumericValue} in milliseconds.
  */
-@FunctionImplementation("datetime.now")
+@FunctionImplementation("date.now")
 public class Now extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Now.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+/**
+ * Returns current UNIX epoch time {@link NumericValue} in milliseconds.
+ */
+@FunctionImplementation("datetime.now")
+public class Now extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(System.currentTimeMillis());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * Returns the current second of the minute as a NumericValue.
+ */
+@FunctionImplementation("datetime.second_of_minute")
+public class SecondOfMinute extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getSecond());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/SecondOfMinute.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * Returns the current second of the minute as a NumericValue.
  */
-@FunctionImplementation("datetime.second_of_minute")
+@FunctionImplementation("date.second_of_minute")
 public class SecondOfMinute extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 /**
  * returns the current week of the month as a NumericValue.
  */
-@FunctionImplementation("datetime.week_of_month")
+@FunctionImplementation("date.week_of_month")
 public class WeekOfMonth extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfMonth.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+/**
+ * returns the current week of the month as a NumericValue.
+ */
+@FunctionImplementation("datetime.week_of_month")
+public class WeekOfMonth extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().get(WeekFields.of(Locale.getDefault()).weekOfMonth()));
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+/**
+ * returns the current week of the year as a NumericValue.
+ */
+@FunctionImplementation("datetime.week_of_year")
+public class WeekOfYear extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().get(WeekFields.of(Locale.getDefault()).weekOfYear()));
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/WeekOfYear.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 /**
  * returns the current week of the year as a NumericValue.
  */
-@FunctionImplementation("datetime.week_of_year")
+@FunctionImplementation("date.week_of_year")
 public class WeekOfYear extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019. Santanu Sinha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.appform.hope.core.functions.impl.date;
+
+import io.appform.hope.core.functions.FunctionImplementation;
+import io.appform.hope.core.functions.HopeFunction;
+import io.appform.hope.core.values.NumericValue;
+import io.appform.hope.core.visitors.Evaluator;
+
+import java.time.LocalDateTime;
+
+/**
+ * returns the current year as a NumericValue.
+ */
+@FunctionImplementation("datetime.year")
+public class Year extends HopeFunction<NumericValue> {
+    @Override
+    public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {
+        return new NumericValue(LocalDateTime.now().getYear());
+    }
+}

--- a/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
+++ b/hope-core/src/main/java/io/appform/hope/core/functions/impl/date/Year.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 /**
  * returns the current year as a NumericValue.
  */
-@FunctionImplementation("datetime.year")
+@FunctionImplementation("date.year")
 public class Year extends HopeFunction<NumericValue> {
     @Override
     public NumericValue apply(Evaluator.EvaluationContext evaluationContext) {

--- a/hope-lang/dependencies.txt
+++ b/hope-lang/dependencies.txt
@@ -1,5 +1,5 @@
-io.appform.hope:hope-lang:jar:2.0.4
-+- io.appform.hope:hope-core:jar:2.0.4:compile
+io.appform.hope:hope-lang:jar:2.0.5
++- io.appform.hope:hope-core:jar:2.0.5:compile
 |  \- org.reflections:reflections:jar:0.9.12:compile
 |     \- org.javassist:javassist:jar:3.26.0-GA:compile
 +- ch.qos.logback:logback-classic:jar:1.2.10:test

--- a/hope-lang/pom.xml
+++ b/hope-lang/pom.xml
@@ -39,6 +39,22 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <includeCurrentProject>true</includeCurrentProject>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.helger.maven</groupId>
                 <artifactId>ph-javacc-maven-plugin</artifactId>
                 <version>4.1.4</version>

--- a/hope-lang/pom.xml
+++ b/hope-lang/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
+++ b/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
@@ -242,8 +242,8 @@ class LibraryFunctionsTest {
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len(\"/array\") == 6", true),
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len('/array') == 6", true),
 
-                Arguments.of("{}", "math.sub(date.now(), %d) <= 2000 && math.sub(date.now(), %d) >= 0".formatted(epochMilli, epochMilli), true),
-                Arguments.of("{}", "math.sub(date.second_of_minute(), %d) <= 1 && math.sub(date.second_of_minute(), %d) >= 0".formatted(dateTime.getSecond(), dateTime.getSecond()), true),
+                Arguments.of("{}", "math.sub(date.now(), %d) <= 10000 && math.sub(date.now(), %d) >= 0".formatted(epochMilli, epochMilli), true),
+                Arguments.of("{}", "math.sub(date.second_of_minute(), %d) <= 10 && math.sub(date.second_of_minute(), %d) >= 0".formatted(dateTime.getSecond(), dateTime.getSecond()), true),
                 Arguments.of("{}", "math.sub(date.minute_of_hour(), %d) <= 1 && math.sub(date.minute_of_hour(), %d) >= 0".formatted(dateTime.getMinute(), dateTime.getMinute()), true),
                 Arguments.of("{}", "math.sub(date.hour_of_day(), %d) <= 1 && math.sub(date.hour_of_day(), %d) >= 0".formatted(dateTime.getHour(), dateTime.getHour()), true),
                 Arguments.of("{}", "math.sub(date.day_of_week(), %d) <= 1 && math.sub(date.day_of_week(), %d) >= 0".formatted(dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue()), true),

--- a/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
+++ b/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
@@ -242,17 +242,17 @@ class LibraryFunctionsTest {
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len(\"/array\") == 6", true),
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len('/array') == 6", true),
 
-                Arguments.of("{}", "math.sub(datetime.now(), %d) <= 1000 && math.sub(datetime.now(), %d) >= 0".formatted(epochMilli, epochMilli), true),
-                Arguments.of("{}", "math.sub(datetime.second_of_minute(), %d) <= 1 && math.sub(datetime.second_of_minute(), %d) >= 0".formatted(dateTime.getSecond(), dateTime.getSecond()), true),
-                Arguments.of("{}", "math.sub(datetime.minute_of_hour(), %d) <= 1 && math.sub(datetime.minute_of_hour(), %d) >= 0".formatted(dateTime.getMinute(), dateTime.getMinute()), true),
-                Arguments.of("{}", "math.sub(datetime.hour_of_day(), %d) <= 1 && math.sub(datetime.hour_of_day(), %d) >= 0".formatted(dateTime.getHour(), dateTime.getHour()), true),
-                Arguments.of("{}", "math.sub(datetime.day_of_week(), %d) <= 1 && math.sub(datetime.day_of_week(), %d) >= 0".formatted(dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue()), true),
-                Arguments.of("{}", "math.sub(datetime.day_of_month(), %d) <= 1 && math.sub(datetime.day_of_month(), %d) >= 0".formatted(dateTime.getDayOfMonth(), dateTime.getDayOfMonth()), true),
-                Arguments.of("{}", "math.sub(datetime.day_of_year(), %d) <= 1 && math.sub(datetime.day_of_year(), %d) >= 0".formatted(dateTime.getDayOfYear(), dateTime.getDayOfYear()), true),
-                Arguments.of("{}", "math.sub(datetime.week_of_month(), %d) <= 1 && math.sub(datetime.week_of_month(), %d) >= 0".formatted(weekOfMonth, weekOfMonth), true),
-                Arguments.of("{}", "math.sub(datetime.week_of_year(), %d) <= 1 && math.sub(datetime.week_of_year(), %d) >= 0".formatted(weekOfYear, weekOfYear), true),
-                Arguments.of("{}", "math.sub(datetime.month_of_year(), %d) <= 1 && math.sub(datetime.month_of_year(), %d) >= 0".formatted(dateTime.getMonth().getValue(), dateTime.getMonth().getValue()), true),
-                Arguments.of("{}", "math.sub(datetime.year(), %d) <= 1 && math.sub(datetime.year(), %d) >= 0".formatted(dateTime.getYear(), dateTime.getYear()), true)
+                Arguments.of("{}", "math.sub(date.now(), %d) <= 2000 && math.sub(date.now(), %d) >= 0".formatted(epochMilli, epochMilli), true),
+                Arguments.of("{}", "math.sub(date.second_of_minute(), %d) <= 1 && math.sub(date.second_of_minute(), %d) >= 0".formatted(dateTime.getSecond(), dateTime.getSecond()), true),
+                Arguments.of("{}", "math.sub(date.minute_of_hour(), %d) <= 1 && math.sub(date.minute_of_hour(), %d) >= 0".formatted(dateTime.getMinute(), dateTime.getMinute()), true),
+                Arguments.of("{}", "math.sub(date.hour_of_day(), %d) <= 1 && math.sub(date.hour_of_day(), %d) >= 0".formatted(dateTime.getHour(), dateTime.getHour()), true),
+                Arguments.of("{}", "math.sub(date.day_of_week(), %d) <= 1 && math.sub(date.day_of_week(), %d) >= 0".formatted(dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue()), true),
+                Arguments.of("{}", "math.sub(date.day_of_month(), %d) <= 1 && math.sub(date.day_of_month(), %d) >= 0".formatted(dateTime.getDayOfMonth(), dateTime.getDayOfMonth()), true),
+                Arguments.of("{}", "math.sub(date.day_of_year(), %d) <= 1 && math.sub(date.day_of_year(), %d) >= 0".formatted(dateTime.getDayOfYear(), dateTime.getDayOfYear()), true),
+                Arguments.of("{}", "math.sub(date.week_of_month(), %d) <= 1 && math.sub(date.week_of_month(), %d) >= 0".formatted(weekOfMonth, weekOfMonth), true),
+                Arguments.of("{}", "math.sub(date.week_of_year(), %d) <= 1 && math.sub(date.week_of_year(), %d) >= 0".formatted(weekOfYear, weekOfYear), true),
+                Arguments.of("{}", "math.sub(date.month_of_year(), %d) <= 1 && math.sub(date.month_of_year(), %d) >= 0".formatted(dateTime.getMonth().getValue(), dateTime.getMonth().getValue()), true),
+                Arguments.of("{}", "math.sub(date.year(), %d) <= 1 && math.sub(date.year(), %d) >= 0".formatted(dateTime.getYear(), dateTime.getYear()), true)
 
                  );
     }

--- a/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
+++ b/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
@@ -242,17 +242,23 @@ class LibraryFunctionsTest {
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len(\"/array\") == 6", true),
                 Arguments.of("{ \"array\" : [1,2,3, 4,8,16] }","arr.len('/array') == 6", true),
 
-                Arguments.of("{}", "math.sub(date.now(), %d) <= 10000 && math.sub(date.now(), %d) >= 0".formatted(epochMilli, epochMilli), true),
-                Arguments.of("{}", "math.sub(date.second_of_minute(), %d) <= 10 && math.sub(date.second_of_minute(), %d) >= 0".formatted(dateTime.getSecond(), dateTime.getSecond()), true),
-                Arguments.of("{}", "math.sub(date.minute_of_hour(), %d) <= 1 && math.sub(date.minute_of_hour(), %d) >= 0".formatted(dateTime.getMinute(), dateTime.getMinute()), true),
-                Arguments.of("{}", "math.sub(date.hour_of_day(), %d) <= 1 && math.sub(date.hour_of_day(), %d) >= 0".formatted(dateTime.getHour(), dateTime.getHour()), true),
-                Arguments.of("{}", "math.sub(date.day_of_week(), %d) <= 1 && math.sub(date.day_of_week(), %d) >= 0".formatted(dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue()), true),
-                Arguments.of("{}", "math.sub(date.day_of_month(), %d) <= 1 && math.sub(date.day_of_month(), %d) >= 0".formatted(dateTime.getDayOfMonth(), dateTime.getDayOfMonth()), true),
-                Arguments.of("{}", "math.sub(date.day_of_year(), %d) <= 1 && math.sub(date.day_of_year(), %d) >= 0".formatted(dateTime.getDayOfYear(), dateTime.getDayOfYear()), true),
-                Arguments.of("{}", "math.sub(date.week_of_month(), %d) <= 1 && math.sub(date.week_of_month(), %d) >= 0".formatted(weekOfMonth, weekOfMonth), true),
-                Arguments.of("{}", "math.sub(date.week_of_year(), %d) <= 1 && math.sub(date.week_of_year(), %d) >= 0".formatted(weekOfYear, weekOfYear), true),
-                Arguments.of("{}", "math.sub(date.month_of_year(), %d) <= 1 && math.sub(date.month_of_year(), %d) >= 0".formatted(dateTime.getMonth().getValue(), dateTime.getMonth().getValue()), true),
-                Arguments.of("{}", "math.sub(date.year(), %d) <= 1 && math.sub(date.year(), %d) >= 0".formatted(dateTime.getYear(), dateTime.getYear()), true)
+                /* below set tests all date functions.
+                * Note: We generate a time at the start of the test and compare the generated values from the builtin function with this time.
+                * But in the off chance that the test is running at the 999th millisecond of the second, the diff can be more than 1 (00-59 = -59)
+                * And the same analogy applies for minute/hour/week etc as all the values are like circular buffers [0,1.2...59..0,1..]
+                * The tests below handle this (so unfortunately, it is a little complicated) */
+
+                Arguments.of("{}", "(math.abs(math.sub(date.now(), %d)) <= 3000 && math.abs(math.sub(date.now(), %d)) >= 0) || (math.abs(math.sub(date.now(), %d)) >= 58000 && math.abs(math.sub(date.now(), %d)) <= 60000)".formatted(epochMilli, epochMilli, epochMilli, epochMilli), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.second_of_minute(), %d)) <= 10 && math.abs(math.sub(date.second_of_minute(), %d)) >= 0) || (math.abs(math.sub(date.second_of_minute(), %d)) <= 60 && math.abs(math.sub(date.second_of_minute(), %d)) >= 58)".formatted(dateTime.getSecond(), dateTime.getSecond(), dateTime.getSecond(), dateTime.getSecond()), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.minute_of_hour(), %d)) <= 1 && math.abs(math.sub(date.minute_of_hour(), %d)) >= 0) || (math.abs(math.sub(date.minute_of_hour(), %d)) <= 60 && math.abs(math.sub(date.minute_of_hour(), %d)) >= 58)".formatted(dateTime.getMinute(), dateTime.getMinute(), dateTime.getMinute(), dateTime.getMinute()), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.hour_of_day(), %d)) <= 1 && math.abs(math.sub(date.hour_of_day(), %d)) >= 0) || (math.abs(math.sub(date.hour_of_day(), %d)) <= 24 && math.abs(math.sub(date.hour_of_day(), %d)) >= 23)".formatted(dateTime.getHour(), dateTime.getHour(), dateTime.getHour(), dateTime.getHour()), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.day_of_week(), %d)) <= 1 && math.abs(math.sub(date.day_of_week(), %d)) >= 0) || (math.abs(math.sub(date.day_of_week(), %d)) <= 7 && math.abs(math.sub(date.day_of_week(), %d)) >= 6)".formatted(dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue(), dateTime.getDayOfWeek().getValue()), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.day_of_month(), %d)) <= 1 && math.abs(math.sub(date.day_of_month(), %d)) >= 0) || (math.abs(math.sub(date.day_of_month(), %d)) <= 31 && math.abs(math.sub(date.day_of_month(), %d)) >= 27)".formatted(dateTime.getDayOfMonth(), dateTime.getDayOfMonth(), dateTime.getDayOfMonth(), dateTime.getDayOfMonth()), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.day_of_year(), %d)) <= 1 && math.abs(math.sub(date.day_of_year(), %d)) >= 0) || (math.abs(math.sub(date.day_of_year(), %d)) <= 366 && math.abs(math.sub(date.day_of_year(), %d)) >= 364)".formatted(dateTime.getDayOfYear(), dateTime.getDayOfYear(), dateTime.getDayOfYear(), dateTime.getDayOfYear()), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.week_of_month(), %d)) <= 1 && math.abs(math.sub(date.week_of_month(), %d)) >= 0) || (math.abs(math.sub(date.week_of_month(), %d)) <= 6 && math.abs(math.sub(date.week_of_month(), %d)) >= 3)".formatted(weekOfMonth, weekOfMonth, weekOfMonth, weekOfMonth), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.week_of_year(), %d)) <= 1 && math.abs(math.sub(date.week_of_year(), %d)) >= 0) || (math.abs(math.sub(date.week_of_year(), %d)) <= 54 && math.abs(math.sub(date.week_of_year(), %d)) >= 51)".formatted(weekOfYear, weekOfYear, weekOfYear, weekOfYear), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.month_of_year(), %d)) <= 1 && math.abs(math.sub(date.month_of_year(), %d)) >= 0) || (math.abs(math.sub(date.month_of_year(), %d)) <= 12 && math.abs(math.sub(date.month_of_year(), %d)) >= 11)".formatted(dateTime.getMonth().getValue(), dateTime.getMonth().getValue(), dateTime.getMonth().getValue(), dateTime.getMonth().getValue()), true),
+                Arguments.of("{}", "(math.abs(math.sub(date.year(), %d)) <= 1 && math.abs(math.sub(date.year(), %d)) >= 0)".formatted(dateTime.getYear(), dateTime.getYear()), true)
 
                  );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
             **/io/appform/hope/lang/jmh_generated/*.java,
             **/io/appform/hope/lang/parser/*.java
         </sonar.exclusions>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/../hope-lang/target/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <dependencyManagement>
@@ -320,19 +323,12 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.9</version>
                 <executions>
                     <execution>
+                        <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <!-- attached to Maven test phase -->
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.hope</groupId>
     <artifactId>hope</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
 
     <name>Hope</name>
     <url>https://github.com/santanusinha/hope</url>


### PR DESCRIPTION
The following are now available as built-in functions
```
datetime.now()
datetime.second_of_minute()
datetime.minute_of_hour()
datetime.hour_of_day()
datetime.day_of_week()
datetime.day_of_month()
datetime.day_of_year()
datetime.week_of_month()
datetime.week_of_year()
datetime.month_of_year()
datetime.year()
```