### PR TITLE
Moving NumericValue to double to ensure correctness during comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use the following dependency in your code.
     <dependency>
         <groupId>io.appform.hope</groupId>
         <artifactId>hope-lang</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </dependency>
 ```
 

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,4 +1,4 @@
-io.appform.hope:hope:pom:2.0.5
+io.appform.hope:hope:pom:2.0.6
 +- org.openjdk.jmh:jmh-core:jar:1.35:test
 |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
 |  \- org.apache.commons:commons-math3:jar:3.2:test

--- a/hope-core/dependencies.txt
+++ b/hope-core/dependencies.txt
@@ -1,4 +1,4 @@
-io.appform.hope:hope-core:jar:2.0.5
+io.appform.hope:hope-core:jar:2.0.6
 +- org.reflections:reflections:jar:0.9.12:compile
 |  \- org.javassist:javassist:jar:3.26.0-GA:compile
 +- org.openjdk.jmh:jmh-core:jar:1.35:test

--- a/hope-core/dependency-reduced-pom.xml
+++ b/hope-core/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>hope</artifactId>
     <groupId>io.appform.hope</groupId>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hope-core</artifactId>

--- a/hope-core/pom.xml
+++ b/hope-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hope-core/src/main/java/io/appform/hope/core/values/NumericValue.java
+++ b/hope-core/src/main/java/io/appform/hope/core/values/NumericValue.java
@@ -25,13 +25,13 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class NumericValue extends EvaluatableValue<Number> {
+public class NumericValue extends EvaluatableValue<Double> {
 
     /**
      * @param value Number value
      */
     public NumericValue(Number value) {
-        super(value);
+        super(value.doubleValue());
     }
 
     /**

--- a/hope-core/src/main/java/io/appform/hope/core/values/NumericValue.java
+++ b/hope-core/src/main/java/io/appform/hope/core/values/NumericValue.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class NumericValue extends EvaluatableValue<Double> {
+public class NumericValue extends EvaluatableValue<Number> {
 
     /**
      * @param value Number value

--- a/hope-lang/dependencies.txt
+++ b/hope-lang/dependencies.txt
@@ -1,5 +1,5 @@
-io.appform.hope:hope-lang:jar:2.0.5
-+- io.appform.hope:hope-core:jar:2.0.5:compile
+io.appform.hope:hope-lang:jar:2.0.6
++- io.appform.hope:hope-core:jar:2.0.6:compile
 |  \- org.reflections:reflections:jar:0.9.12:compile
 |     \- org.javassist:javassist:jar:3.26.0-GA:compile
 +- ch.qos.logback:logback-classic:jar:1.2.10:test

--- a/hope-lang/pom.xml
+++ b/hope-lang/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
+++ b/hope-lang/src/test/java/io/appform/hope/lang/LibraryFunctionsTest.java
@@ -258,7 +258,8 @@ class LibraryFunctionsTest {
                 Arguments.of("{}", "(math.abs(math.sub(date.week_of_month(), %d)) <= 1 && math.abs(math.sub(date.week_of_month(), %d)) >= 0) || (math.abs(math.sub(date.week_of_month(), %d)) <= 6 && math.abs(math.sub(date.week_of_month(), %d)) >= 3)".formatted(weekOfMonth, weekOfMonth, weekOfMonth, weekOfMonth), true),
                 Arguments.of("{}", "(math.abs(math.sub(date.week_of_year(), %d)) <= 1 && math.abs(math.sub(date.week_of_year(), %d)) >= 0) || (math.abs(math.sub(date.week_of_year(), %d)) <= 54 && math.abs(math.sub(date.week_of_year(), %d)) >= 51)".formatted(weekOfYear, weekOfYear, weekOfYear, weekOfYear), true),
                 Arguments.of("{}", "(math.abs(math.sub(date.month_of_year(), %d)) <= 1 && math.abs(math.sub(date.month_of_year(), %d)) >= 0) || (math.abs(math.sub(date.month_of_year(), %d)) <= 12 && math.abs(math.sub(date.month_of_year(), %d)) >= 11)".formatted(dateTime.getMonth().getValue(), dateTime.getMonth().getValue(), dateTime.getMonth().getValue(), dateTime.getMonth().getValue()), true),
-                Arguments.of("{}", "(math.abs(math.sub(date.year(), %d)) <= 1 && math.abs(math.sub(date.year(), %d)) >= 0)".formatted(dateTime.getYear(), dateTime.getYear()), true)
+                Arguments.of("{}", "(math.abs(math.sub(date.year(), %d)) <= 1 && math.abs(math.sub(date.year(), %d)) >= 0)".formatted(dateTime.getYear(), dateTime.getYear()), true),
+                Arguments.of("{}", "date.week_of_month() == 1 || date.week_of_month() == 2 || date.week_of_month() == 3 || date.week_of_month() == 4 || date.week_of_month() == 5", true)
 
                  );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.hope</groupId>
     <artifactId>hope</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
 
     <name>Hope</name>
     <url>https://github.com/santanusinha/hope</url>


### PR DESCRIPTION
NumericValue using Number would bring in ambiguities during comparison.
So functions like these would fail because 3 is read as `Double` and NumericValue from builtin function returns `Integer`
```java
date.week_of_month() == 3
```
This PR moves it to Double by default, to ensure comparison is always against the same datatype