### PR TITLE
reflection version upgrade to 0.10.2

### DIFF
--- a/hope-core/dependency-reduced-pom.xml
+++ b/hope-core/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>hope</artifactId>
     <groupId>io.appform.hope</groupId>
-    <version>2.0.6</version>
+    <version>2.0.7</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hope-core</artifactId>

--- a/hope-core/pom.xml
+++ b/hope-core/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.12</version>
+            <version>0.10.2</version>
         </dependency>
     </dependencies>
 

--- a/hope-core/pom.xml
+++ b/hope-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hope-lang/pom.xml
+++ b/hope-lang/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hope</artifactId>
         <groupId>io.appform.hope</groupId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.hope</groupId>
     <artifactId>hope</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.6</version>
+    <version>2.0.7</version>
 
     <name>Hope</name>
     <url>https://github.com/santanusinha/hope</url>


### PR DESCRIPTION
older reflection version is throwing warning
```

INFO  | 2024-11-17 22:49:27,980 | InstanceLogHandler             | WARN  [2024-11-17 22:49:27,979] [main] [Reflections]: could not get type for name org.zeroturnaround.javarebel.ClassEventListener from any class loader
INFO  | 2024-11-17 22:49:27,980 | InstanceLogHandler             | io.appform.shaded.org.reflections.ReflectionsException: could not get type for name org.zeroturnaround.javarebel.ClassEventListener
INFO  | 2024-11-17 22:49:27,980 | InstanceLogHandler             | 	at io.appform.shaded.org.reflections.ReflectionUtils.forName(ReflectionUtils.java:312)
INFO  | 2024-11-17 22:49:27,980 | InstanceLogHandler             | 	at io.appform.shaded.org.reflections.Reflections.expandSuperTypes(Reflections.java:382)
INFO  | 2024-11-17 22:49:27,980 | InstanceLogHandler             | 	at io.appform.shaded.org.reflections.Reflections.<init>(Reflections.java:140)
INFO  | 2024-11-17 22:49:27,980 | InstanceLogHandler             | 	at io.appform.hope.core.functions.FunctionRegistry.discover(FunctionRegistry.java:78)
INFO  | 2024-11-17 22:49:27,980 | InstanceLogHandler             | 	at io.appform.hope.lang.HopeLangEngine$Builder.build(HopeLangEngine.java:144)
```