### PR TITLE
Fix: Replace JacksonJsonNodeJsonProvider with JacksonJsonProvider to eliminate valueToTree allocation storm

### DIFF
--- a/hope-core/src/main/java/io/appform/hope/core/utils/Converters.java
+++ b/hope-core/src/main/java/io/appform/hope/core/utils/Converters.java
@@ -15,7 +15,6 @@
 package io.appform.hope.core.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -54,8 +53,6 @@ import java.util.stream.StreamSupport;
  */
 @Slf4j
 public class Converters {
-
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private Converters() {
     }
@@ -651,7 +648,7 @@ public class Converters {
                     if (result instanceof JsonNode jsonNode) {
                         return jsonNode;
                     }
-                    return MAPPER.valueToTree(result);
+                    return Evaluator.getMapper().valueToTree(result);
                 });
     }
 

--- a/hope-core/src/main/java/io/appform/hope/core/utils/Converters.java
+++ b/hope-core/src/main/java/io/appform/hope/core/utils/Converters.java
@@ -15,6 +15,7 @@
 package io.appform.hope.core.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -53,6 +54,8 @@ import java.util.stream.StreamSupport;
  */
 @Slf4j
 public class Converters {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private Converters() {
     }
@@ -641,10 +644,14 @@ public class Converters {
         final Map<String, JsonNode> jsonPathEvalCache = evaluationContext.getJsonPathEvalCache();
         return jsonPathEvalCache
                 .computeIfAbsent(path, key -> {
-                    final JsonNode value = evaluationContext.getJsonContext().read(jsonPathValue.getJsonPath());
-                    return null == value
-                           ? NullNode.getInstance()
-                           : value;
+                    final Object result = evaluationContext.getJsonContext().read(jsonPathValue.getJsonPath());
+                    if (result == null) {
+                        return NullNode.getInstance();
+                    }
+                    if (result instanceof JsonNode jsonNode) {
+                        return jsonNode;
+                    }
+                    return MAPPER.valueToTree(result);
                 });
     }
 

--- a/hope-core/src/main/java/io/appform/hope/core/visitors/Evaluator.java
+++ b/hope-core/src/main/java/io/appform/hope/core/visitors/Evaluator.java
@@ -22,7 +22,7 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ParseContext;
-import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import io.appform.hope.core.Evaluatable;
 import io.appform.hope.core.VisitorAdapter;
 import io.appform.hope.core.combiners.AndCombiner;
@@ -45,6 +45,7 @@ import lombok.Getter;
 import lombok.val;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,20 +74,20 @@ public class Evaluator {
     public Evaluator(ErrorHandlingStrategy errorHandlingStrategy) {
         this.errorHandlingStrategy = errorHandlingStrategy;
         parseContext = JsonPath.using(Configuration.builder()
-                .jsonProvider(new JacksonJsonNodeJsonProvider())
+                .jsonProvider(new JacksonJsonProvider(mapper))
                 .options(Option.SUPPRESS_EXCEPTIONS)
                 .build());
 
     }
 
     public boolean evaluate(Evaluatable evaluatable, JsonNode node) {
-        return evaluatable.accept(new LogicEvaluator(new EvaluationContext(parseContext.parse(node), node, this)));
+        return evaluatable.accept(new LogicEvaluator(new EvaluationContext(parseContext.parse(toPojo(node)), node, this)));
     }
 
     public List<Boolean> evaluate(
             final List<Evaluatable> evaluatables,
             final JsonNode node) {
-        val logicEvaluator = new LogicEvaluator(new EvaluationContext(parseContext.parse(node), node, this));
+        val logicEvaluator = new LogicEvaluator(new EvaluationContext(parseContext.parse(toPojo(node)), node, this));
         val list = new ArrayList<Boolean>(evaluatables.size());
         for (final Evaluatable evaluatable : evaluatables) {
             Boolean accept = evaluatable.accept(logicEvaluator);
@@ -98,7 +99,7 @@ public class Evaluator {
     public OptionalInt evaluateFirst(
             final List<Evaluatable> rules,
             final JsonNode node) {
-        val logicEvaluator = new LogicEvaluator(new EvaluationContext(parseContext.parse(node), node, this));
+        val logicEvaluator = new LogicEvaluator(new EvaluationContext(parseContext.parse(toPojo(node)), node, this));
         val bound = rules.size();
         for (int index = 0; index < bound; index++) {
             if (rules.get(index).accept(logicEvaluator)) {
@@ -106,6 +107,11 @@ public class Evaluator {
             }
         }
         return OptionalInt.empty();
+    }
+
+    private static Object toPojo(JsonNode node) {
+        final Object pojo = mapper.convertValue(node, Object.class);
+        return pojo != null ? pojo : Collections.emptyMap();
     }
 
     @Data

--- a/hope-core/src/main/java/io/appform/hope/core/visitors/Evaluator.java
+++ b/hope-core/src/main/java/io/appform/hope/core/visitors/Evaluator.java
@@ -56,6 +56,7 @@ import java.util.OptionalInt;
  * Evaluates a hope expression
  */
 public class Evaluator {
+    @Getter
     private static final ObjectMapper mapper = new ObjectMapper();
 
     static {


### PR DESCRIPTION
### Problem

`JacksonJsonNodeJsonProvider` calls `objectMapper.valueToTree()` for **every intermediate path element** during JsonPath traversal. At large scale, each touching hundreds of keys, this creates massive GC pressure and allocation storms.

**Per-evaluation allocation chain:**

```
Evaluator constructor
 └─ new JacksonJsonNodeJsonProvider()

Evaluator.evaluate()
 └─ parseContext.parse(jsonNode)

For EACH JsonPath expression:
 └─ jsonContext.read(jsonPath)
    └─ JacksonJsonNodeJsonProvider.setArrayIndex()
       └─ objectMapper.valueToTree(result)  ← called per intermediate path step
```

This regressed in bonsai 2.0.6, which pulled in hope-lang 2.0.9 where the `Evaluator` switched to `JacksonJsonNodeJsonProvider` (operates on `JsonNode`, requires serialization) from `JacksonJsonProvider` (operates on POJOs, no serialization).

### Fix

Switched the JsonPath provider from `JacksonJsonNodeJsonProvider` back to `JacksonJsonProvider`:

- **`Evaluator.java`** - Use `JacksonJsonProvider(mapper)`. Convert incoming `JsonNode` to a POJO once via `mapper.convertValue()` before parsing.
- **`Converters.java`** - `nodeForJsonPath()` now receives a POJO from `read()` instead of `JsonNode`. Convert the final result to `JsonNode` via `valueToTree()` once per unique path (already cached).

### Impact

| Before | After |
|---|---|
| `valueToTree()` called **N times per path element** during traversal | `convertValue()` once per evaluation + `valueToTree()` once per unique path (cached) |
| New `JacksonJsonNodeJsonProvider` + `Configuration` + `ParseContext` per `Evaluator` | Same, but with `JacksonJsonProvider` (no intermediate serialization) |